### PR TITLE
Resume bug zapper after rain stops

### DIFF
--- a/Bug Zapper Automation/bug_zapper_control
+++ b/Bug Zapper Automation/bug_zapper_control
@@ -77,12 +77,21 @@ action:
             target:
               entity_id: !input rain_hold_helper
       - conditions:
-          - condition: or
-            conditions:
-              - condition: trigger
-                id: "2"  # Sunrise
-              - condition: trigger
-                id: "3"  # Starts raining
+          - condition: trigger
+            id: "3"  # Starts raining
+          - condition: state
+            entity_id: !input zapper_switch
+            state: "on"
+        sequence:
+          - service: switch.turn_off
+            target:
+              entity_id: !input zapper_switch
+          - service: input_boolean.turn_on
+            target:
+              entity_id: !input rain_hold_helper
+      - conditions:
+          - condition: trigger
+            id: "2"  # Sunrise
           - condition: state
             entity_id: !input zapper_switch
             state: "on"

--- a/Bug Zapper Automation/readme.md
+++ b/Bug Zapper Automation/readme.md
@@ -1,11 +1,11 @@
 ## 🐞 Bug Zapper - Noon to Dawn with Rain Check
 
-This Home Assistant automation blueprint turns on an outdoor bug zapper at **noon** if the weather is dry, and turns it off at **dawn** or if it starts raining. If it was raining at noon, it remembers this and will **turn the zapper on later** when the rain stops (as long as it's still before dawn).
+This Home Assistant automation blueprint turns on an outdoor bug zapper at **noon** if the weather is dry, turns it off at **dawn** or when it starts raining, and resumes after the rain if noon was rainy or the zapper was stopped by rain.
 
 ### 💡 Features
 - Turns on a switch at **12:00 PM** if weather is not `rainy`
 - Turns **off at dawn** (sunrise) or immediately if it starts raining
-- If it was rainy at noon, it will turn the zapper **on when the rain clears**, only before dawn
+- If it was rainy at noon or rain stops the zapper later, it will turn the zapper **back on when the rain clears**, only before dawn
 - Uses an `input_boolean` helper to track rain-delayed activations
 
 ---


### PR DESCRIPTION
## Summary
- resume bug zapper when rain that caused a shutdown ends
- document this new behaviour in the blueprint README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e10726cc8333afbf01c0567f3c19