### PR TITLE
Add version numbers to blueprint names

### DIFF
--- a/Bug Zapper Automation/bug_zapper_control
+++ b/Bug Zapper Automation/bug_zapper_control
@@ -1,6 +1,8 @@
 blueprint:
-  name: Bug Zapper - Noon to Dawn with Rain Check
-  description: Turns on a switch at noon if weather is dry, turns off at dawn or when raining, and resumes after rain if noon was rainy.
+  name: "Bug Zapper - Noon to Dawn with Rain Check (v1.0)"
+  description: >
+    📦 Version: 1.0.0
+    Turns on a switch at noon if weather is dry, turns off at dawn or when raining, and resumes after rain if noon was rainy.
   domain: automation
   input:
     zapper_switch:

--- a/Bug Zapper Automation/readme.md
+++ b/Bug Zapper Automation/readme.md
@@ -1,4 +1,4 @@
-## 🐞 Bug Zapper - Noon to Dawn with Rain Check
+## 🐞 Bug Zapper - Noon to Dawn with Rain Check (v1.0)
 
 This Home Assistant automation blueprint turns on an outdoor bug zapper at **noon** if the weather is dry, and turns it off at **dawn** or if it starts raining. If it was raining at noon, it remembers this and will **turn the zapper on later** when the rain stops (as long as it's still before dawn).
 
@@ -40,7 +40,7 @@ config/blueprints/automation/[your_username]/bug_zapper_rain.yaml
 ```
 
 2. In Home Assistant, go to **Settings > Automations & Scenes > Blueprints > Import Blueprint**
-3. Choose **"Bug Zapper - Noon to Dawn with Rain Check"**
+3. Choose **"Bug Zapper - Noon to Dawn with Rain Check (v1.0)"**
 4. Configure the automation:
    - **Bug Zapper Switch**: Your zapper plug/switch entity
    - **Weather Condition Sensor**: Your weather sensor (e.g., OpenWeather)

--- a/Front Lights Person Detected/person_detected_lights_flexible.yaml
+++ b/Front Lights Person Detected/person_detected_lights_flexible.yaml
@@ -1,7 +1,7 @@
 blueprint:
-  name: "👤✨ Person Detected Light Control"
+  name: "👤✨ Person Detected Light Control (v3.1.1)"
   description: >
-    📦 Version: 3.1.0
+    📦 Version: 3.1.1
     🔔 Triggers when a person is detected between sunset and sunrise.
     💡 Turns on specified lights if they are off.
     ⏲️ Turns off lights after a specified delay.


### PR DESCRIPTION
## Summary
- include a visible version in the Bug Zapper blueprint name and description
- bump the Person Detected blueprint version and include it in the name
- update README references to the new Bug Zapper versioned name

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841e22b1f2c8333be48b7a19b9a39df