### PR TITLE
Fix bug zapper resume check

### DIFF
--- a/Bug Zapper Automation/bug_zapper_control
+++ b/Bug Zapper Automation/bug_zapper_control
@@ -1,7 +1,7 @@
 blueprint:
-  name: "Bug Zapper - Flexible Schedule with Rain Check (v2.0)"
+  name: "Bug Zapper - Flexible Schedule with Rain Check (v2.1)"
   description: >
-    📦 Version: 2.0.0
+    📦 Version: 2.1.0
     Runs the bug zapper on a flexible schedule. Pick either a fixed time or
     sun event (sunrise, sunset, dawn or dusk) to turn it on and choose another
     time or sun event to turn it off—you can mix and match. Dawn and dusk are
@@ -166,7 +166,11 @@ action:
           - condition: template
             value_template: >-
               {% if off_event == 'time' %}
-                {{ now() < today_at(off_time) }}
+                {% set off_ts = as_timestamp(today_at(off_time)) %}
+                {% if off_ts < as_timestamp(now()) %}
+                  {% set off_ts = off_ts + 86400 %}
+                {% endif %}
+                {{ as_timestamp(now()) < off_ts }}
               {% else %}
                 {{ now() < as_local(state_attr('sun.sun', 'next_' ~ off_event)) }}
               {% endif %}

--- a/Bug Zapper Automation/readme.md
+++ b/Bug Zapper Automation/readme.md
@@ -1,10 +1,13 @@
-## 🐞 Bug Zapper - Flexible Schedule with Rain Check (v2.0)
+## 🐞 Bug Zapper - Flexible Schedule with Rain Check (v2.1)
 
 This blueprint lets you run your outdoor bug zapper on your own schedule.
 For the on and off triggers you can choose either a fixed time or a sun event
 (sunrise, sunset, dawn or dusk) and mix them however you like. If it starts
 raining the zapper is turned off and it will automatically resume once the
-weather clears, as long as your chosen off time hasn't passed.
+weather clears, as long as your chosen off time hasn't passed. When using a
+time-based off trigger that crosses midnight (for example, on at sunset and off
+at 6:00 AM), the blueprint checks the next day's off time so the zapper can
+restart if the rain ends before then.
 
 
 ### 💡 Features
@@ -41,7 +44,7 @@ input_boolean:
 config/blueprints/automation/[your_username]/bug_zapper_rain.yaml
 ```
 2. In Home Assistant go to **Settings → Automations & Scenes → Blueprints → Import Blueprint**
-3. Choose **"Bug Zapper - Flexible Schedule with Rain Check (v2.0)"**
+3. Choose **"Bug Zapper - Flexible Schedule with Rain Check (v2.1)"**
 4. Configure the automation:
    - **Bug Zapper Switch**: Your zapper plug/switch entity
    - **Weather Condition Sensor**: Your weather sensor (e.g., OpenWeather)


### PR DESCRIPTION
## Summary
- handle schedules that cross midnight when resuming after rain
- document new behavior and bump blueprint to v2.1

## Testing
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846543c2f288333a19c5956fc4af8dc